### PR TITLE
Configure dependabot for weekly Friday updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "friday"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"


### PR DESCRIPTION
## Summary
- Schedule gomod updates every Friday
- Add github-actions ecosystem so CI action versions are tracked too

## Test plan
- [ ] CI green (no code changes, but dependabot config will be validated by GitHub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)